### PR TITLE
Keep some internals methods and properties protected.

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -11,7 +11,7 @@ class FakeTask:
 @pytest.mark.usefixtures("engine")
 def test_check_argument(engine):
     with pytest.raises(InvalidArgumentError):
-        engine.check_argument(FakeTask)
+        engine.execute([FakeTask])
 
 
 @pytest.mark.usefixtures("engine", "task0", "sequential_workflow")
@@ -26,6 +26,3 @@ def test_dispatch_task(client, engine, task0, mocker):
     mocker.spy(client, "start_task")
     task0.dispatch()
     assert client.start_task.call_count == 1
-
-
-

--- a/zenaton/engine.py
+++ b/zenaton/engine.py
@@ -23,7 +23,7 @@ class Engine(metaclass=Singleton):
         @return [Array<String>, nil] the results if executed locally, or nil
     """
     def execute(self, jobs):
-        map(self.check_argument, jobs)
+        map(Engine._check_argument, jobs)
         if len(jobs) == 0 or self.processor is None:
             return [job.handle() for job in jobs]
         return self.processor.process(jobs, True)
@@ -34,7 +34,7 @@ class Engine(metaclass=Singleton):
         @return nil
     """
     def dispatch(self, jobs):
-        map(self.check_argument, jobs)
+        map(Engine._check_argument, jobs)
         if len(jobs) == 0 or self.processor is None:
             [self.local_dispatch(job) for job in jobs]
         if self.processor and len(jobs) > 0:
@@ -46,12 +46,14 @@ class Engine(metaclass=Singleton):
         else:
             self.client.start_task(job)
 
-    def check_argument(self, job):
-        if not self.valid_job(job):
+    @staticmethod
+    def _check_argument(job):
+        if not Engine.valid_job(job):
             raise InvalidArgumentError('You can only execute or dispatch Zenaton Task or Worflow')
 
     """
         Checks if the job is a valid job i.e. it is either a Task or a Workflow
     """
-    def valid_job(self, job):
+    @staticmethod
+    def valid_job(job):
         return issubclass(job.__class__, Task) or issubclass(job.__class__, Workflow)

--- a/zenaton/query/builder.py
+++ b/zenaton/query/builder.py
@@ -7,12 +7,12 @@ class Builder:
 
     def __init__(self, class_):
         from ..client import Client
-        self.check_class(class_)
+        self._check_class(class_)
         self.class_ = class_
         self.client = Client()
 
     """
-        Sets the id of the workflow we want to find
+        Sets the where_id of the workflow we want to find
         :param String or None id the id
         :returns Builder the current builder
     """
@@ -64,7 +64,7 @@ class Builder:
         :param class class_
     """
 
-    def check_class(self, class_):
+    def _check_class(self, class_):
         msg = '{} should be a subclass of .abstracts.workflow'.format(class_)
         if not issubclass(class_, Workflow):
             raise ExternalError(msg)

--- a/zenaton/services/properties.py
+++ b/zenaton/services/properties.py
@@ -42,11 +42,11 @@ class Properties:
 
     def object_from(self, class_, properties, super_class=None):
         object_ = self.blank_instance(class_)
-        self.check_class(object_, super_class)
+        self._check_class(object_, super_class)
         self.set(object_, properties)
         return object_
 
-    def check_class(self, object_, super_class):
+    def _check_class(self, object_, super_class):
         error_message = 'Error - #{object.class} should be an instance of #{super_class}'
         if not issubclass(type(object_), super_class):
             raise Exception(error_message)


### PR DESCRIPTION
### Summary

Having some internal properties shown as public makes the API of some classes confusing. I have tried to switch those properties and methods to be protected using the python convention to prefix them with `_`.

### Safety check

| Q                         | A
| ------------------------- | ---
| Type                      | enhancement
| Related issues            | None
| Code covered with tests?  | yes
| Changelog updated?        | no
| Documentation updated?    | no
