### PR TITLE
Use isinstance instead of issubclass of type.

### DIFF
--- a/tests/fixtures/fixture_workflow.py
+++ b/tests/fixtures/fixture_workflow.py
@@ -31,11 +31,7 @@ class SequentialWorkflow(Workflow, Zenatonable):
         self.id_ = id_
 
     def on_event(self, event):
-        if issubclass(MyEvent, type(event)):
-            return True
-        else:
-            return False
-
+        return isinstance(event, MyEvent)
 
 
 @pytest.fixture

--- a/zenaton/client.py
+++ b/zenaton/client.py
@@ -201,7 +201,7 @@ class Client(metaclass=Singleton):
         return custom_id
 
     def canonical_name(self, flow):
-        return type(flow).__name__ if issubclass(type(flow), Version) else None
+        return type(flow).__name__ if isintance(flow, Version) else None
 
     def class_name(self, flow):
         if issubclass(type(flow), Version):

--- a/zenaton/engine.py
+++ b/zenaton/engine.py
@@ -41,7 +41,7 @@ class Engine(metaclass=Singleton):
             self.processor.process(jobs, False)
 
     def local_dispatch(self, job):
-        if issubclass(job.__class__, Workflow):
+        if isinstance(job, Workflow):
             self.client.start_workflow(job)
         else:
             self.client.start_task(job)
@@ -54,4 +54,4 @@ class Engine(metaclass=Singleton):
         Checks if the job is a valid job i.e. it is either a Task or a Workflow
     """
     def valid_job(self, job):
-        return issubclass(job.__class__, Task) or issubclass(job.__class__, Workflow)
+        return isinstance(job, (Task, Workflow))

--- a/zenaton/services/properties.py
+++ b/zenaton/services/properties.py
@@ -48,7 +48,7 @@ class Properties:
 
     def check_class(self, object_, super_class):
         error_message = 'Error - #{object.class} should be an instance of #{super_class}'
-        if not issubclass(type(object_), super_class):
+        if not isinstance(object_, super_class):
             raise Exception(error_message)
 
     def valid_object(self, object_, super_class):
@@ -64,7 +64,7 @@ class Properties:
         if isinstance(object_, datetime.time):
             return {'hour': object_.hour, 'minute': object_.minute, 'second': object_.second,
                     'microsecond': object_.microsecond, 'tzinfo': object_.tzinfo}
-        if issubclass(type(object_), BaseException):
+        if isinstance(object_, BaseException):
             return {'error_class': object_.__class__.__name__, 'error_args': list(object_.args)}
         return json.dumps(object_)
 


### PR DESCRIPTION
### Summary

The codebase does not use much the builtin python function `isinstance` and instead use a twisted way to do the same thing. This PR fixes all calls to `issubclass` that are actually trying to check `isinstance`.

### Safety check

| Q                         | A
| ------------------------- | ---
| Type                      | enhancement
| Related issues            | None
| Code covered with tests?  | yes
| Changelog updated?        | no
| Documentation updated?    | no
