### PR TITLE
Stop requiring unused API token in boot module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- No need for credentials when this lib is running in a Zenaton agent except if dispatching a
+  sub-job.
 
 ### Changed
 

--- a/zenaton/client.py
+++ b/zenaton/client.py
@@ -42,13 +42,18 @@ class Client(metaclass=Singleton):
     WORKFLOW_PAUSE = 'pause'  # Worker udpate mode to pause a worker
     WORKFLOW_RUN = 'run'  # Worker update mode to resume a worker
 
-    def __init__(self, app_id, api_token, app_env):
+    def __init__(self, app_id='', api_token='', app_env=''):
         self.app_id = app_id
         self.api_token = api_token
         self.app_env = app_env
         self.http = HttpService()
         self.serializer = Serializer()
         self.properties = Properties()
+
+    def __lazy_init__(self, app_id, api_token, app_env):
+        self.app_id = self.app_id or app_id
+        self.api_token = self.api_token or api_token
+        self.app_env = self.app_env or app_env
 
     """
         Gets the url for the workers
@@ -70,6 +75,8 @@ class Client(metaclass=Singleton):
     """
     def website_url(self, resource='', params=''):
         api_url = os.environ.get('ZENATON_API_URL') or self.ZENATON_API_URL
+        if not self.api_token:
+            raise ValueError('Client not initialized to access website: missing an API token.')
         url = '{}/{}?{}={}&'.format(api_url, resource, self.API_TOKEN, self.api_token)
         return self.add_app_env(url, params)
 

--- a/zenaton/singleton.py
+++ b/zenaton/singleton.py
@@ -4,4 +4,6 @@ class Singleton(type):
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        elif (args or kwargs) and hasattr(cls._instances[cls], '__lazy_init__'):
+            cls._instances[cls].__lazy_init__(*args, **kwargs)
         return cls._instances[cls]


### PR DESCRIPTION
### Summary

As @geomagilles told me, the code in tasks does not usually require a complete client (as it's already running on the agent), however as it's calling `client.Client()` it breaks if credentials are not given before that.

This PR allows a Client to be created even without credentials. It still yells if the credentials are missing for other use cases.

### Safety check

| Q                         | A
| ------------------------- | ---
| Type                      | enhancement
| Related issues            | None
| Code covered with tests?  | yes
| Changelog updated?        | yes
| Documentation updated?    | no
